### PR TITLE
Fix the logical error of arm64 in  build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ while getopts ":d:m:v:" opt; do
   m)
       TARGET=$OPTARG
       if [[ "${TARGET}" == "arm64" ]]; then
-        if [[ "${MACHINE_TYPE}" != "aarch64" ]] ||  [[ "${MACHINE_TYPE}" != "arm64" ]]; then
+        if [[ "${MACHINE_TYPE}" != "aarch64" ]] &&  [[ "${MACHINE_TYPE}" != "arm64" ]]; then
           echo "-m arm64 is supported only when running on an ARM64 system."
           exit;
         fi


### PR DESCRIPTION
fix the bug https://github.com/GoogleCloudPlatform/cloud-profiler-java/issues/48
it's a logical error,
should use Logical and (&&) instead of Logical or (||) between two negative condition:
```
if [[ "${MACHINE_TYPE}" != "aarch64" ]] && [[ "${MACHINE_TYPE}" != "arm64" ]]
```